### PR TITLE
The order in the lib doesn't reflect the README

### DIFF
--- a/strconv.py
+++ b/strconv.py
@@ -295,8 +295,8 @@ default_strconv = Strconv(converters=[
     ('float', convert_float),
     ('bool', convert_bool),
     ('time', convert_time),
-    ('datetime', convert_datetime),
     ('date', convert_date),
+    ('datetime', convert_datetime),
 ])
 
 register_converter = default_strconv.register_converter


### PR DESCRIPTION
According to https://github.com/bruth/strconv#converters the "date" should come before the "datetime".


Currently we're unregistering the "datetime" converter to get around this bug.