### PR TITLE
Properly convert dates with no timestamp to dates instead of datetimes

### DIFF
--- a/strconv.py
+++ b/strconv.py
@@ -250,7 +250,9 @@ def convert_bool(s):
 def convert_datetime(s, date_formats=DATE_FORMATS, time_formats=TIME_FORMATS):
     if duparse:
         try:
-            return duparse(s)
+            dt = duparse(s)
+            if dt.time():
+                return duparse(s)
         except TypeError:  # parse may throw this in py3
             raise ValueError
 
@@ -259,7 +261,9 @@ def convert_datetime(s, date_formats=DATE_FORMATS, time_formats=TIME_FORMATS):
             for sep in DATE_TIME_SEPS:
                 f = '{0}{1}{2}'.format(df, sep, tf)
                 try:
-                    return datetime.strptime(s, f)
+                    dt = datetime.strptime(s, f)
+                    if dt.time():
+                        return dt
                 except ValueError:
                     pass
     raise ValueError

--- a/test_strconv.py
+++ b/test_strconv.py
@@ -44,7 +44,7 @@ class ConvertTestCase(unittest.TestCase):
         self.assertEqual(strconv.convert('-3'), -3)
         self.assertEqual(strconv.convert('+0.4'), 0.4)
         self.assertEqual(strconv.convert('true'), True)
-        self.assertEqual(strconv.convert('3/20/2013'), datetime(2013, 3, 20))
+        self.assertEqual(strconv.convert('3/20/2013'), date(2013, 3, 20))
         self.assertEqual(strconv.convert('5:40 PM'), time(17, 40))
         self.assertEqual(strconv.convert('March 4, 2013 5:40 PM'),
                          datetime(2013, 3, 4, 17, 40, 0))
@@ -64,7 +64,7 @@ class InferTestCase(unittest.TestCase):
         self.assertEqual(strconv.infer('-3'), 'int')
         self.assertEqual(strconv.infer('+0.4'), 'float')
         self.assertEqual(strconv.infer('true'), 'bool')
-        self.assertEqual(strconv.infer('3/20/2013'), 'datetime')
+        self.assertEqual(strconv.infer('3/20/2013'), 'date')
         self.assertEqual(strconv.infer('5:40 PM'), 'time')
         self.assertEqual(strconv.infer('March 4, 2013 5:40 PM'), 'datetime')
 
@@ -72,7 +72,7 @@ class InferTestCase(unittest.TestCase):
         self.assertEqual(strconv.infer('-3', converted=True), int)
         self.assertEqual(strconv.infer('+0.4', converted=True), float)
         self.assertEqual(strconv.infer('true', converted=True), bool)
-        self.assertEqual(strconv.infer('3/20/2013', converted=True), datetime)
+        self.assertEqual(strconv.infer('3/20/2013', converted=True), date)
         self.assertEqual(strconv.infer('5:40 PM', converted=True), time)
         self.assertEqual(strconv.infer('March 4, 2013 5:40 PM',
                          converted=True), datetime)


### PR DESCRIPTION
In the README it lists that the lib should convert to dates then datetimes (https://github.com/bruth/strconv#converters). I've found that it will convert a date string to a datetime object instead with all 0's for the time information. By checking if the time is zero'd out and passing if that's the case we can properly convert dates with no time information to actual date objects instead of datetimes.