### PR TITLE
Fixed bug in Types.__repr__

### DIFF
--- a/strconv.py
+++ b/strconv.py
@@ -46,7 +46,7 @@ class Types(object):
 
     def __repr__(self):
         types = self.most_common()
-        label = ', '.join(['{0}={1}'.format(t, i.count) for t, i in types])
+        label = ', '.join(['{0}={1}'.format(t, i) for t, i in types])
         return '<{0}: {1}>'.format(self.__class__.__name__, label)
 
     def incr(self, t, n=1):


### PR DESCRIPTION
[Counter.most_common](https://docs.python.org/2/library/collections.html#collections.Counter.most_common) returns a list of tuples in the form `(value, count)` where `count` is an integer. So when `Type.__repr__` evaluates`i.count`, an error occurs.

This small change evaluates the literal integer `i` instead of `i.count`