### PR TITLE
When converting a date time where the time is '00:00:00' infer returns a date type instead of date time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .coverage
 dist
 MANIFEST
+.idea*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 
 python:
     - "2.7"
-    - "3.2"
     - "3.3"
+    - "3.5"
+    - "3.6"
 
 install:
     - pip install -q coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: python
 
 python:
     - "2.7"
-    - "3.2.5"
+    - "3.2"
     - "3.3"
-    - "3.5"
 
 install:
     - pip install -q coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "3.3"
 
 install:
-    - pip install -q coveralls --use-mirrors
+    - pip install -q coveralls
     - pip install -r requirements.txt
     - pip install flake8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 
 python:
     - "2.7"
-    - "3.2"
+    - "3.2.5"
     - "3.3"
+    - "3.5"
 
 install:
     - pip install -q coveralls

--- a/strconv.py
+++ b/strconv.py
@@ -1,9 +1,9 @@
+import re
+import sys
 
 from collections import Counter
 from datetime import datetime
-import re
 
-import sys
 
 __version__ = '0.4.1'
 # strconv.py

--- a/strconv.py
+++ b/strconv.py
@@ -1,10 +1,12 @@
+
+from collections import Counter
+from datetime import datetime
+import re
+
+__version__ = '0.4.1'
 # strconv.py
 # Copyright (c) 2013 Byron Ruth
 # BSD License
-
-__version__ = '0.4.1'
-
-from collections import Counter
 
 
 class TypeInfo(object):
@@ -189,10 +191,6 @@ class Strconv(object):
 
 
 # Built-in converters
-
-import re
-
-from datetime import datetime
 
 # Use dateutil for more robust parsing
 try:

--- a/strconv.py
+++ b/strconv.py
@@ -3,6 +3,8 @@ from collections import Counter
 from datetime import datetime
 import re
 
+import sys
+
 __version__ = '0.4.1'
 # strconv.py
 # Copyright (c) 2013 Byron Ruth
@@ -220,7 +222,9 @@ TIME_FORMATS = (
     '%H:%M:%S',
     '%H:%M',
     '%I:%M:%S %p',
+    '%I:%M:%S %z',
     '%I:%M %p',
+    '%I:%M %z',
     '%I:%M',
 )
 
@@ -247,13 +251,14 @@ def convert_bool(s):
 
 
 def convert_datetime(s, date_formats=DATE_FORMATS, time_formats=TIME_FORMATS):
-    if duparse:
-        try:
-            dt = duparse(s)
-            if dt.time():
-                return duparse(s)
-        except TypeError:  # parse may throw this in py3
-            raise ValueError
+    if sys.version < '3.5':
+        if duparse:
+            try:
+                dt = duparse(s)
+                if dt.time():
+                    return duparse(s)
+            except TypeError:  # parse may throw this in py3
+                raise ValueError
 
     for df in date_formats:
         for tf in time_formats:

--- a/strconv.py
+++ b/strconv.py
@@ -208,6 +208,7 @@ except ImportError:
 DATE_FORMATS = (
     '%Y-%m-%d',
     '%m-%d-%Y',
+    '%Y/%m/%d',
     '%m/%d/%Y',
     '%m.%d.%Y',
     '%m-%d-%y',
@@ -261,9 +262,7 @@ def convert_datetime(s, date_formats=DATE_FORMATS, time_formats=TIME_FORMATS):
             for sep in DATE_TIME_SEPS:
                 f = '{0}{1}{2}'.format(df, sep, tf)
                 try:
-                    dt = datetime.strptime(s, f)
-                    if dt.time():
-                        return dt
+                    return datetime.strptime(s, f)
                 except ValueError:
                     pass
     raise ValueError

--- a/test_strconv.py
+++ b/test_strconv.py
@@ -48,6 +48,8 @@ class ConvertTestCase(unittest.TestCase):
         self.assertEqual(strconv.convert('5:40 PM'), time(17, 40))
         self.assertEqual(strconv.convert('March 4, 2013 5:40 PM'),
                          datetime(2013, 3, 4, 17, 40, 0))
+        self.assertEqual(strconv.convert('March 4, 2013 12:00 AM'),
+                         datetime(2013, 3, 4, 0, 0))
 
     def test_convert_include_type(self):
         self.assertEqual(strconv.convert('-3', include_type=True), (-3, 'int'))
@@ -67,6 +69,13 @@ class InferTestCase(unittest.TestCase):
         self.assertEqual(strconv.infer('3/20/2013'), 'date')
         self.assertEqual(strconv.infer('5:40 PM'), 'time')
         self.assertEqual(strconv.infer('March 4, 2013 5:40 PM'), 'datetime')
+        self.assertEqual(strconv.infer('2018-12-01 00:00:00'), 'datetime')
+        self.assertEqual(strconv.infer('March 4, 2013 12:00 PM'), 'datetime')
+        # Midnight
+        self.assertEqual(strconv.convert_datetime('2013-03-01 00:00:00'),
+                         datetime(2013, 3, 1, 0, 0, 0))
+        self.assertEqual(strconv.convert_datetime('2018/03/01 00:00:00'),
+                         datetime(2018, 3, 1, 0, 0, 0))
 
     def test_infer_converted(self):
         self.assertEqual(strconv.infer('-3', converted=True), int)
@@ -158,6 +167,7 @@ class ConverterTestCase(unittest.TestCase):
         # TZ
         self.assertEqual(strconv.convert_datetime('2013-03-01 5:30:40 -0500'),
                          datetime(2013, 3, 1, 5, 30, 40, tzinfo=tzoff))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Solved this by removing if  if dt.time() in the date_formats loop in the convert_datetime() method.